### PR TITLE
Remove top margin causing blank space at top of page

### DIFF
--- a/app/_scss/pages/_case-page.scss
+++ b/app/_scss/pages/_case-page.scss
@@ -29,10 +29,6 @@
 	}
 }
 
-#case-page {
-  margin-top: 45px;
-}
-
 .case {
   h1,
   h2,


### PR DESCRIPTION
This removes errant blank space at top of case studies.

**Before:**
![fireshot capture 17 - gambling on cow insurance - http___www gizra com_case-studies_ibli_](https://cloud.githubusercontent.com/assets/688507/15504810/5cd2cba2-2186-11e6-85f0-0bbf3fa7c081.png)

**After:**
![fireshot capture 18 - gambling on cow insurance - http___0 0 0 0_9000_case-studies_ibli_](https://cloud.githubusercontent.com/assets/688507/15504816/5ff7d052-2186-11e6-8ea6-05a0d1772e71.png)

