### PR TITLE
Three across blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ pygments: true
 title : Gizra
 excerpt_separator: "<!-- more -->"
 
-paginate: 10
+paginate: 12
 paginate_path: "blog/page:num"
 
 url: http://www.gizra.com

--- a/app/_scss/pages/_blog-page.scss
+++ b/app/_scss/pages/_blog-page.scss
@@ -46,13 +46,10 @@
   margin-bottom: 20px;
 
   .post-teaser {
-    @extend .soft-box;
     box-shadow: none;
     position: relative;
-    margin-bottom: 28px;
-    padding-top: 10px;
-    padding-bottom: 7px;
-    border-radius: 6px;
+    margin-bottom: 1.5em;
+    padding: 5px;
 
     > * {
       margin-right: 10px;
@@ -134,11 +131,10 @@
 
 @include desktop {
   .blog .article .main-image {
-    height: 275px;
+    height: 185px;
   }
 
   .post-teaser {
-    height: 400px;
     overflow: hidden;
   }
 }

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -18,8 +18,29 @@ blog: true
       <div class="col-sm-10 col-sm-offset-1 blog">
         <h1 class="title">The Gizra Blog</h1>
         <div class="row posts">
-          {% for post in paginator.posts %}
-            <div class="col-sm-6">
+          {% for post in paginator.posts limit:3 %}
+            <div class="col-sm-4">
+              {% include post_teaser.html img_number=forloop.index %}
+            </div>
+          {% endfor %}
+        </div>
+        <div class="row posts">
+          {% for post in paginator.posts limit:3 offset:3 %}
+            <div class="col-sm-4">
+              {% include post_teaser.html img_number=forloop.index %}
+            </div>
+          {% endfor %}
+        </div>
+        <div class="row posts">
+          {% for post in paginator.posts limit:3 offset:6 %}
+            <div class="col-sm-4">
+              {% include post_teaser.html img_number=forloop.index %}
+            </div>
+          {% endfor %}
+        </div>
+        <div class="row posts">
+          {% for post in paginator.posts limit:3 offset:9 %}
+            <div class="col-sm-4">
               {% include post_teaser.html img_number=forloop.index %}
             </div>
           {% endfor %}

--- a/app/index.html
+++ b/app/index.html
@@ -49,8 +49,8 @@ homepage: true
         <div class="col-sm-10 col-sm-offset-1 blog">
           <h2 class="title"><a href="/blog">From our blog</a></h2>
           <div class="row">
-            {% for post in site.posts limit:2 %}
-            <div class="col-sm-6">
+            {% for post in site.posts limit:6 %}
+            <div class="col-sm-4">
               {% include post_teaser.html img_number=forloop.index %}
             </div>
             {% endfor %}


### PR DESCRIPTION
Iteration 1 - #470

This is a variation on a previous suggestion that takes the original design and refines a bit.
- removes the soft box: I know there's some disagreement here, but the card-like presentation seems a bit dated to me. I added some padding to the gutters so that here's more separation, and I think every thing seems distinct.
- Gave each row a bootstrap row class so that they can behave independently. That way if there is a 3 line title, it will only provide extra space on that row.
- removed the height designation on the box itself and added 1.5 em margin to the bottom - provides nice uniform spacing.

Note: we need to standardize thumbnail sizes... it causes a mess on mobile view.
![fireshot capture 124 - gizra s blog - http___0 0 0 0_9000_blog_index html](https://cloud.githubusercontent.com/assets/688507/18411539/df3bfa38-773e-11e6-8cc9-47e0c7614a60.png)
