### PR TITLE
Change Homepage text and add "Our Story" page

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -71,6 +71,9 @@
     <a class="item" href="/projects">
       Projects
     </a>
+    <a class="item" href="/our-story">
+      Our Story
+    </a>
     <a class="item" href="/contact">
       Contact
     </a>

--- a/src/_layouts/story.html
+++ b/src/_layouts/story.html
@@ -4,9 +4,9 @@ layout: default
 
 <div class="ui grid centered story">
   <div class="twelve wide column">
-    <div class="ui raised padded segment {{ page.color }}">
+    <div class="ui basic segment">
 
-      <h1 class="ui dividing header">
+      <h1 class="ui dividing header {{ page.color }}">
         <div class="content">
           <a href="{{ page.url }}">{{ page.title }} </a>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,6 @@ title: Design + Web Development | Gizra
         is in your hands.
       </p>
 
-      {% include stories.html %}
     </div>
 
   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -13,23 +13,61 @@ title: Design + Web Development | Gizra
         see mostly text, and move on.
       </p>
 
-      <p>Maybe they're right. But we think it's not that people don’t want to
+      <p>
+        Maybe they're right. But we think it's not that people don’t want to
         read; rather they don’t want to read boring, meaningless marketing copy.
       </p>
+
       <p>
-        It’s really difficult to explain exactly who we are. It's not that we haven't
-        tried, but we inevitably ended up using words that have long lost their meaning.
-        Seriously, how can words like &ldquo;trust&rdquo; or &ldquo;innovation&rdquo;
-        be taken seriously when stuck inside a tag line? Plus, this exercise of describing
-        yourself in short is incomplete. Can you explain in one sentence who you are? Even
-        if you could, wouldn’t it be missing so much?
+        So how about this - your problem is not a technology one. Quite
+        surprising coming from a technology company, right? But it's true.
+        It's not about having a responsive design, or an add to cart, or some
+        fancy feature. It's about what is needed to support your goals - how you
+        define success and measure it.
       </p>
+
       <p>
-        In any case, we believe writing this is worth the risk.
+        Let's be honest, most IT projects fail - they don't meet the deadline,
+        they exceed the budget, and no one seems to be pleased. If this were a
+        one-on-one meeting, this is the point in our pitch we would look into
+        your eyes and search for that spark of understanding. Some have it,
+        some don't. If you are still reading this, it's safe to assume you know
+        what we are talking about.
       </p>
+
       <p>
-        So we wrote three (short) stories that we hope will give you a glimpse into our
-        mindset. We have a good feeling about this, but who knows - it's for you to decide.
+        It's 2017. We're in an age where things are moving really fast. No one
+        will wait for you 9 month. Heck, we'd argue no one will wait for you 9
+        minutes. So you need to get it out there. Fast. And get real feedback
+        from real people. Fast.
+      </p>
+
+      <p>
+        Forget those long specifications; forget those over-engineered features
+        before there's even a single user; forget those old fashioned work
+        methods that just add bureaucracy, but don't guarantee results.
+      </p>
+
+      <p>
+        We care only about the results. We've failed many times. Way too many
+        times. But we have also had our good share of success. You see, this is
+        not in theory, it's about experience and the constant understanding that
+        "there must be a better way". And it’s working for Harvard University,
+        the EU, the UN, and many other startups and NGOs. If you are ready to
+        take this path with us, it will work for you.
+      </p>
+
+      <p>
+        Sure, we're not your typical web development agency. When we partner
+        with you, it's not just as developers, but rather as business
+        technologists. We're committed to one thing - making your project
+        successful, so our relationship with you lasts for many years.
+      </p>
+
+      <p>
+        Once you contact us, we will know how to guide you in this process.
+        We've done it many times. But this first crucial step of contacting us
+        is in your hands.
       </p>
 
       {% include stories.html %}

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,7 @@ title: Design + Web Development | Gizra
         is in your hands.
       </p>
 
+      {% include stories.html %}
     </div>
 
   </div>

--- a/src/our-story/index.html
+++ b/src/our-story/index.html
@@ -1,0 +1,23 @@
+---
+layout: story
+title: Our Story
+description: Our story told as 3 different stories
+---
+
+<p>
+  It’s quite difficult to explain exactly who we are. It's not that we haven't
+  tried, but we inevitably ended up using words that have long lost their meaning.
+  Seriously, how can words like &ldquo;trust&rdquo; or &ldquo;innovation&rdquo;
+  be taken seriously when stuck inside a tag line? Plus, this exercise of describing
+  yourself in short is incomplete. Can you explain in one sentence who you are? Even
+  if you could, wouldn’t it be missing so much?
+</p>
+
+<p>
+  In any case, we believe writing this is worth the risk.
+</p>
+
+<p>
+  So we wrote three (short) stories that we hope will give you a glimpse into our
+  mindset. We have a good feeling about this, but who knows - it's for you to decide.
+</p>


### PR DESCRIPTION
Re-written homepage text:

![design___web_development___gizra](https://cloud.githubusercontent.com/assets/125707/25865677/54cc950c-34fc-11e7-840e-31b3551d575a.jpg)

The previous home page text moved to own page and removed the white background from the story (i.e. `ui basic segment`):

![our_story](https://cloud.githubusercontent.com/assets/125707/25865649/40c61b0a-34fc-11e7-85a9-5f75bd7f6b19.jpg)
