### PR TITLE
Change blog titles to h2 on listing page

### DIFF
--- a/src/_includes/post_teaser.html
+++ b/src/_includes/post_teaser.html
@@ -35,7 +35,7 @@
   </a>
 
   <div class="content">
-    <div class="header"><a href="{{ post.url }}">{{ post.title }}</a></div>
+    <h2 class="header"><a href="{{ post.url }}">{{ post.title }}</a></h2>
   </div>
 
   {% if post.description %}


### PR DESCRIPTION
#663 

Same visual appearance:

<img width="1192" alt="gizra_s_blog" src="https://user-images.githubusercontent.com/688507/36644644-e86fb030-1a22-11e8-9a5e-b1ab65f99e72.png">

New HTML

<img width="765" alt="gizra_s_blog" src="https://user-images.githubusercontent.com/688507/36644664-3c1360ce-1a23-11e8-843d-67c92bc794bf.png">

