### PR TITLE
Remove underscore after a colon

### DIFF
--- a/src/_posts/2018-04-23-stress-test.md
+++ b/src/_posts/2018-04-23-stress-test.md
@@ -108,7 +108,7 @@ Here, we issue a single HTTP request at the host, to retrieve the [blog page](ht
 
 ### Headers
 
-Real browsers do send various headers alongside the request, we can make it more realistic this way:_
+Real browsers do send various headers alongside the request, we can make it more realistic this way:
 ```scala
 val httpProtocol = http
   .acceptHeader("*/*")


### PR DESCRIPTION
I did not read all the blog post but I spot this one.